### PR TITLE
Upgrade 1.8 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Accept bitcoins on your WHMCS, payments go directly into your wallet
 The entire file structure has been refactored to match the WHMCS code standard and the code has been ported to comply the syntax PSR2 for PHP.
 
 - Just upload and replace the folder `modules` in your own WHMCS installation with the one we provide. You don't need to upload any other folder or file like `screnshots` or `README.md`.
-- Now just execute the script using your browser, this is located in: https://xxxxxxx.ccc/modules/gateways/blockonomics/updater.php (replace xxxxxxx.ccc with your own WHMCS domain)
+- Now just execute the script updater.php using your browser. Example: https://xxxxxxx.ccc/modules/gateways/blockonomics/updater.php (replace xxxxxxx.ccc with your own WHMCS domain)
 - That's it!
 
 ## Screenshots ##

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ Accept bitcoins on your WHMCS, payments go directly into your wallet
 ## Installation ##
 [Blog Tutorial](https://blog.blockonomics.co/friendly-bitcoin-payments-for-web-hosting-businesses-using-whmcs-88de8eef4e81) | [Video Tutorial](https://www.youtube.com/watch?v=jORcxsV-OOg)
 
-- Copy the files to your WHMCS directory
+- Copy the folder `modules` to your WHMCS directory. You don't need to upload any other folder or file like `screnshots` or `README.md`.
 - Go to your WHMCS admin, Setup -> Payments -> Payment Gateways
 - Activate Blockonomics in All Payment Gateways
 - Set your API key in Manage Existing Gateways
 - After setting API Key refresh page
 - Copy your Callback to Blockonomics Merchants > Settings
 
-## Upgrade from 1.8.X to 1.9 ##
+## Upgrade from 1.8.X to 1.9.X ##
 The entire file structure has been refactored to match the WHMCS code standard and the code has been ported to comply the syntax PSR2 for PHP.
-- Delete the folders css/ img/ js/ located in your WHMCS root installation. They are now located inside the module.
-- Delete the files payment.php testSetup.php located in your WHMCS root installation.
-- Delete the folder templates/blockonomics since the template now is located inside the module.
-- Replace using the content located in modules/gateways into your WHMCS.
+
+- Just upload and replace the folder `modules` in your own WHMCS installation with the one we provide. You don't need to upload any other folder or file like `screnshots` or `README.md`.
+- Now just execute the script using your browser, this is located in: https://xxxxxxx.ccc/modules/gateways/blockonomics/updater.php (replace xxxxxxx.ccc with your own WHMCS domain)
+- That's it!
 
 ## Screenshots ##
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Accept bitcoins on your WHMCS, payments go directly into your wallet
 The entire file structure has been refactored to match the WHMCS code standard and the code has been ported to comply the syntax PSR2 for PHP.
 
 - Just upload and replace the folder `modules` in your own WHMCS installation with the one we provide. You don't need to upload any other folder or file like `screnshots` or `README.md`.
-- Now just execute the script updater.php using your browser. Example: https://xxxxxxx.ccc/modules/gateways/blockonomics/updater.php (replace xxxxxxx.ccc with your own WHMCS domain)
+- Now just execute the script upgrade.php using your browser. Example: https://xxxxxxx.ccc/modules/gateways/blockonomics/upgrade.php (replace xxxxxxx.ccc with your own WHMCS domain)
 - That's it!
 
 ## Screenshots ##

--- a/modules/gateways/blockonomics/upgrade.php
+++ b/modules/gateways/blockonomics/upgrade.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This script will delete old files from previuos 1.8.2 version.
+ * First delete files and folder that we know belong to blockonomics only
+ * Then we delete the folders if they are empty
+ * We also check if the screeshots folder and README.md file was installed and belongs to blockonomics so we can delete them too.
+ */
+
+require_once __DIR__ . '/../../../init.php';
+require_once __DIR__ . '/blockonomics.php';
+
+use Blockonomics\Blockonomics;
+
+$blockonomics = new Blockonomics();
+if (doubleval($blockonomics->getVersion()) < 1.9) {
+    exit('Version 1.9 or higher must be installed before executing this upgrader.');
+}
+
+// List of files to be deleted
+$filesToDelete = [
+    '/payment.php',
+    '/testSetup.php',
+    '/css/order.css',
+    '/img/bch.png',
+    '/img/btc.png',
+    '/js/angular-resource.min.js',
+    '/js/angular.min.js',
+    '/js/app.js',
+    '/js/reconnecting-websocket.min.js',
+    '/screenshots/screenshot-1.png',
+    '/screenshots/screenshot-2.png',
+    '/screenshots/screenshot-3.png',
+];
+
+// List of folders to delete, those are safe to be deleted since it belongs to Blockonomics only.
+$foldersToDeleteNonCheck = [
+    '/js/angular-qrcode',
+    '/js/qrcode-generator',
+    '/templates/blockonomics',
+    '/modules/gateways/Blockonomics',
+];
+
+// List of folders to be deleted, after check if are empty and not affecting any other plugin
+$foldersToDeleteChecking = [
+    '/css',
+    '/img',
+    '/js',
+    '/screenshots',
+];
+
+try {
+    // Start deleting individual files
+    foreach ($filesToDelete as $fileToDelete) {
+        $path = ROOTDIR . $fileToDelete;
+        if (file_exists($path)) {
+            $FileManager = new \WHMCS\File($path);
+            $FileManager->delete();
+        }
+    }
+
+    // Delete safe folders
+    foreach ($foldersToDeleteNonCheck as $folderToDeleteNonCheck) {
+        $path = ROOTDIR . $folderToDeleteNonCheck;
+        if (file_exists($path)) {
+            $FileUtility = new WHMCS\Utility\File();
+            $FileUtility->recursiveDelete($path, [], true);
+        }
+    }
+
+    // Inspect if remaining folders are empty before delete them.
+    foreach ($foldersToDeleteChecking as $folderToDeleteChecking) {
+        $path = ROOTDIR . $folderToDeleteChecking;
+        if (file_exists($path) && (count(scandir($path)) == 2)) {
+            $FileUtility = new WHMCS\Utility\File();
+            $FileUtility->recursiveDelete($path, [], true);
+        }
+    }
+
+    // Finally the README.md file should not be in the root folder either and due the previous
+    // installation instructions some user may have this file there
+    $path = ROOTDIR . '/README.md';
+    $readmeIsBlockonomics = false;
+    if (file_exists($path)) {
+        if (strpos(file_get_contents($path), 'Blockonomics') !== false) {
+            $readmeIsBlockonomics = true;
+        }
+
+        if (file_exists($path) && $readmeIsBlockonomics) {
+            $FileManager = new \WHMCS\File($path);
+            $FileManager->delete();
+        }
+    }
+
+    exit('Upgrade process has been completed.');
+} catch (\Throwable $th) {
+    //throw $th;
+    echo $th->getMessage();
+}


### PR DESCRIPTION
A quick solution for the update process due the new structure in 1.9.x

It does this in steps (see more details in the code comments):

- It deletes old files we know are safe because belongs to our plugin only.
- It deletes old folders we know are safe because belongs to our plugin.
- After deleting, if parent folders are now empty (like `/css` or `/img`) then we can delete them with confidence.
- Also deletes `screenshot` and `README.md` after previous evaluation, in case it was uploaded by accident.

This is still a draft, open to discution.
