### PR TITLE
(fix) Add Admin Session Check before running Upgrade or TestSetup Scripts

### DIFF
--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -155,7 +155,9 @@ class Blockonomics
      */
     public function checkAdmin()
     {
-        if (!is_null($_SESSION['adminid'])) {
+        $currentUser = new \WHMCS\Authentication\CurrentUser;
+
+        if ($currentUser->isAuthenticatedAdmin()) {
             return TRUE;
         } else {
             http_response_code(403);

--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -151,7 +151,7 @@ class Blockonomics
 
     /**
      * Check if Admin or Exit
-     * Ref: https://whmcs.community/topic/300798-how-to-understand-if-an-admin-is-logged-in-as-user/?do=findComment&comment=1334307
+     * Ref: https://developers.whmcs.com/advanced/authentication/
      */
     public function checkAdmin()
     {

--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -149,6 +149,20 @@ class Blockonomics
         return 2;
     }
 
+    /**
+     * Check if Admin or Exit
+     * Ref: https://whmcs.community/topic/300798-how-to-understand-if-an-admin-is-logged-in-as-user/?do=findComment&comment=1334307
+     */
+    public function checkAdmin()
+    {
+        if (!is_null($_SESSION['adminid'])) {
+            return TRUE;
+        } else {
+            http_response_code(403);
+            exit("Permission Denied. You should be an admin to perform this action!");
+        }
+    }
+
     /*
      * Update invoice note
      */

--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -155,9 +155,18 @@ class Blockonomics
      */
     public function checkAdmin()
     {
-        $currentUser = new \WHMCS\Authentication\CurrentUser;
+        global $CONFIG;
 
-        if ($currentUser->isAuthenticatedAdmin()) {
+        $isAdmin = FALSE;
+
+        if (version_compare($CONFIG['Version']) >= 0) {
+            $currentUser = new \WHMCS\Authentication\CurrentUser;
+            $isAdmin = $currentUser->isAuthenticatedAdmin();
+        } else {
+            $isAdmin = !is_null($_SESSION['adminid']);
+        }
+
+        if ($isAdmin) {
             return TRUE;
         } else {
             http_response_code(403);

--- a/modules/gateways/blockonomics/testsetup.php
+++ b/modules/gateways/blockonomics/testsetup.php
@@ -6,5 +6,7 @@ require_once __DIR__ . '/blockonomics.php';
 use Blockonomics\Blockonomics;
 
 $blockonomics = new Blockonomics();
+$blockonomics->checkAdmin();
+
 $error = $blockonomics->testSetup();
 echo json_encode($error);

--- a/modules/gateways/blockonomics/upgrade.php
+++ b/modules/gateways/blockonomics/upgrade.php
@@ -12,6 +12,8 @@ require_once __DIR__ . '/blockonomics.php';
 use Blockonomics\Blockonomics;
 
 $blockonomics = new Blockonomics();
+$blockonomics->checkAdmin();
+
 if (doubleval($blockonomics->getVersion()) < 1.9) {
     exit('Version 1.9 or higher must be installed before executing this upgrader.');
 }


### PR DESCRIPTION
Check if the Current User is Admin before running Upgrade or TestSetup PHP Scripts

Returns 403 Otherwise with the message.