### PR TITLE
(fix) Activation Issue in WHMCS 8.6

### DIFF
--- a/modules/gateways/blockonomics/whmcs.json
+++ b/modules/gateways/blockonomics/whmcs.json
@@ -1,7 +1,7 @@
 {
     "schema": "1.0",
     "type": "whmcs-gateways",
-    "name": "Blockonomics",
+    "name": "blockonomics",
     "license": "MIT",
     "category": "payments",
     "description": {


### PR DESCRIPTION
It seems WHMCS implemented something due to which the name in whmcs.json should match with directory, correcting the case seems to make the module work!

Closes #142 