### PR TITLE
[CRITICAL] Fix version_compare should have 2 parameters

### DIFF
--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -159,7 +159,7 @@ class Blockonomics
 
         $isAdmin = FALSE;
 
-        if (version_compare($CONFIG['Version']) >= 0) {
+        if (version_compare($CONFIG['Version'], "8.0.0") >= 0) {
             $currentUser = new \WHMCS\Authentication\CurrentUser;
             $isAdmin = $currentUser->isAuthenticatedAdmin();
         } else {


### PR DESCRIPTION
`version_compare` should have 2 parameters for comparison, this is a critical issue causing testsetup and other scripts using [checkAdmin()](https://github.com/blockonomics/whmcs-bitcoin-plugin/blob/master/modules/gateways/blockonomics/blockonomics.php#L156) to fail.