### PR TITLE
Test setup debugging - Add new store error

### DIFF
--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -838,7 +838,8 @@ class Blockonomics
         }
 
         // No match and no empty callback
-        $response->debug_error = "No match found";  
+        $response->debug_error = "No match found";
+        $response->base_url = $base_url;
         $error_str = json_encode($response);
 
         return $error_str;

--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -780,8 +780,9 @@ class Blockonomics
 
         $error_str = '';
 
-        if (!isset($response->data) || count($response->data) == 0) {
-            $error_str = $_BLOCKLANG['testSetup']['addStore'];
+        if (empty($response->data) || count($response->data) == 0) {
+            $response->debug_error = "No response data";  
+            $error_str = json_encode($response);
         }
         //if merchant has at least one xPub on his Blockonomics account
         elseif (count($response->data) >= 1)
@@ -836,8 +837,9 @@ class Blockonomics
             return '';
         }
 
-        // No match and no empty callbac        
-        $error_str = $_BLOCKLANG['testSetup']['addStore'];
+        // No match and no empty callback
+        $response->debug_error = "No match found";  
+        $error_str = json_encode($response);
 
         return $error_str;
     }


### PR DESCRIPTION
Add debugging for add new store test setup issues. Tells us if the add new store issue is due to either:

- Existing Callback URL's not fetched correctly from Blockonomics
- Comparing existing Callback URL to current Callback URL is not recognising the matching callback