### PR TITLE
Fixing for usdt server job exec check and the sleep time 

### DIFF
--- a/modules/gateways/blockonomics/blockonomics.php
+++ b/modules/gateways/blockonomics/blockonomics.php
@@ -1086,9 +1086,7 @@ class Blockonomics
             return;
         }
 
-        $disabled_functions = ini_get('disable_functions');
-        
-        if (strpos($disabled_functions, 'exec') !== false) {
+        if (!function_exists('exec')) {
             if (function_exists('logModuleCall')) {
                 logModuleCall(
                     "Blockonomics",

--- a/modules/gateways/blockonomics/pollTransactionStatus.php
+++ b/modules/gateways/blockonomics/pollTransactionStatus.php
@@ -152,7 +152,6 @@ function getPaymentAmount($bits, $tokenAmount, $order) {
 
 do {
     try {        
-        logMessage("Polling", "Starting to poll", "true");
         sleep(1);
         $unconfirmedOrders = $blockonomics->getUnconfirmedUSDTOrders();
         

--- a/modules/gateways/blockonomics/pollTransactionStatus.php
+++ b/modules/gateways/blockonomics/pollTransactionStatus.php
@@ -151,25 +151,18 @@ function getPaymentAmount($bits, $tokenAmount, $order) {
 
 
 do {
-    // Get the server's max execution time
-    $max_execution_time = ini_get('max_execution_time');
-    
-    // If max_execution_time is 0 (unlimited) or greater than 30, use 20 seconds
-    // Otherwise, use half of the max_execution_time, but not less than 10 seconds
-    $sleep_time = ($max_execution_time == 0 || $max_execution_time > 30) ? 20 : max(10, $max_execution_time / 2);
-    
-    sleep($sleep_time);
-    
-    // Log the sleep time for debugging
-    logMessage("Sleep Time", "Server max execution time: $max_execution_time", "Actual sleep time: $sleep_time");
-    $unconfirmedOrders = $blockonomics->getUnconfirmedUSDTOrders();
-    
-    if (!$unconfirmedOrders->isEmpty()) {
-        foreach ($unconfirmedOrders as $order) {
-            pollTransactionStatus($order);
-            // Use a shorter sleep time between processing each order
-            $order_sleep_time = min(1, $sleep_time / 10);
-            sleep($order_sleep_time);
+    try {        
+        logMessage("Polling", "Starting to poll", "true");
+        sleep(1);
+        $unconfirmedOrders = $blockonomics->getUnconfirmedUSDTOrders();
+        
+        if (!$unconfirmedOrders->isEmpty()) {
+            foreach ($unconfirmedOrders as $order) {
+                pollTransactionStatus($order);
+                sleep(1);
+            }
         }
+    } catch (Exception $e) {
+        logMessage("Error", "An error occurred during polling transaction status", $e->getMessage());
     }
 } while (true);

--- a/modules/gateways/blockonomics/pollTransactionStatus.php
+++ b/modules/gateways/blockonomics/pollTransactionStatus.php
@@ -151,13 +151,25 @@ function getPaymentAmount($bits, $tokenAmount, $order) {
 
 
 do {
-    sleep(60); // Wait for 60 seconds
+    // Get the server's max execution time
+    $max_execution_time = ini_get('max_execution_time');
+    
+    // If max_execution_time is 0 (unlimited) or greater than 30, use 20 seconds
+    // Otherwise, use half of the max_execution_time, but not less than 10 seconds
+    $sleep_time = ($max_execution_time == 0 || $max_execution_time > 30) ? 20 : max(10, $max_execution_time / 2);
+    
+    sleep($sleep_time);
+    
+    // Log the sleep time for debugging
+    logMessage("Sleep Time", "Server max execution time: $max_execution_time", "Actual sleep time: $sleep_time");
     $unconfirmedOrders = $blockonomics->getUnconfirmedUSDTOrders();
     
     if (!$unconfirmedOrders->isEmpty()) {
         foreach ($unconfirmedOrders as $order) {
             pollTransactionStatus($order);
-            sleep(1);
+            // Use a shorter sleep time between processing each order
+            $order_sleep_time = min(1, $sleep_time / 10);
+            sleep($order_sleep_time);
         }
     }
 } while (true);

--- a/modules/gateways/blockonomics/pollTransactionStatus.php
+++ b/modules/gateways/blockonomics/pollTransactionStatus.php
@@ -35,23 +35,14 @@ function performCurlRequest($url) {
 
 // Main function to poll transaction status
 function pollTransactionStatus($order) {
-    global $apiKey, $domain;
-    
     $txHash = $order->txid;
-    $url = "$domain/api?module=transaction&action=getstatus&txhash=$txHash&apikey=$apiKey";
+    $result = fetchTransactionData($txHash);
 
-    logMessage("Polling ","Request sent to etherscan server started for transaction: $txHash ","Start");
-    
-    $response = performCurlRequest($url);
-    $data = json_decode($response, true);
-
-    if ($data['message'] === "NOTOK" || $data['status'] === "0") {
-        logMessage("Polling","Requested Transaction $txHash failed.",$data['message']);
+    if ( $result['blockHash'] == null ||  $result['blockNumber'] == null) {
+        logMessage("Polling","Requested Transaction is still pending /failed and  $txHash failed.",$result['transactionIndex']);
         return;
-    }
-
-    if ($data['status'] === "1") {
-        process($order);
+    } else {
+        process($order, $result);
         logMessage("Polling", " Requested Transaction $txHash to check whether it is completed successfully or not.", "Completed");
         return;
     }
@@ -59,14 +50,13 @@ function pollTransactionStatus($order) {
     logMessage("Polling","Request checks whether transaction ended: $txHash","Ended");
 }
 
-function process($order) {
+function process($order, $result) {
     global $blockonomics;
     global $gatewayParams;
     global $gatewayModuleName;
     
     $txHash = $order->txid;
-
-    $result = fetchTransactionData($txHash);
+    
     $inputData = $result['input'];
     $toAddress = $result['to'];
     $selectedNetwork = $blockonomics->getTokenNetwork();


### PR DESCRIPTION

This PR addresses the issue caused when checking if the exec job is running. Additionally, since the sleep interval of 60 seconds can vary between servers, the logic for the sleep time has been adjusted.

1. For checking the exec function, we initially used `$disabled_functions = ini_get('disable_functions');` as the command does not work on the server. We have replaced it with `(!function_exists('exec'))`.

2. We have changed the sleep time logic, as the sleep interval varies from server to server, causing the job to not work properly.